### PR TITLE
no age shaming

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,6 @@
 		"service_worker": "src/js/background.js",
 		"type": "module"
 	},
-	"minimum_chrome_version": "116",
+	"minimum_chrome_version": "1",
 	"options_page": "src/html/settings.html"
 }


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version ___+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)